### PR TITLE
Upload coverage via codecov bash script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Tooling.
 .coverage
+coverage.xml
 venv*/
 
 # Caches.

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -30,12 +30,6 @@ jobs:
           pythonVersion: $(pythonVersion)
       - script: scripts/test
         displayName: "Run tests"
-      - script: |
-          if [ -f .coverage ]; then
-            python -m pip install codecov;
-            codecov --required;
-          fi
+      - script: curl -s https://codecov.io/bash | bash
         condition: eq(variables['uploadCoverage'], true)
-        env:
-          CODECOV_TOKEN: $(codecovToken)
         displayName: "Upload coverage"

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -30,6 +30,7 @@ jobs:
           pythonVersion: $(pythonVersion)
       - script: scripts/test
         displayName: "Run tests"
-      - script: curl -s https://codecov.io/bash | bash
+      - script: |
+          bash <(curl -s https://codecov.io/bash) -Z -C $(Build.SourceVersion)
         condition: eq(variables['uploadCoverage'], true)
         displayName: "Upload coverage"

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,4 +21,5 @@ addopts =
   --cov=arel
   --cov=tests
   --cov-report=term-missing
+  --cov-report=xml
   --cov-fail-under=100


### PR DESCRIPTION
Seems like pipeline secrets (like secret variables) aren't made available to forks by default in Azure Pipelines. This causes #5 to fail.

Trying the Codecov bash script instead of uploading via `python-codecov`, which shouldn't require the `CODECOV_TOKEN` env var on Azure.