### PR TITLE
Use 2.0 CI templates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 # Tooling.
 .coverage
-coverage.xml
 venv*/
 
 # Caches.

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: github
       name: florimondmanca/azure-pipelines-templates
-      ref: refs/tags/1.0
+      ref: refs/tags/2.0
 
 trigger:
   - master

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,5 +21,4 @@ addopts =
   --cov=arel
   --cov=tests
   --cov-report=term-missing
-  --cov-report=xml
   --cov-fail-under=100


### PR DESCRIPTION
Reverts some changes from #7, as `2.0` supports XML coverage conversion automatically.

See https://github.com/florimondmanca/azure-pipelines-templates/blob/master/CHANGELOG.md