### PR TITLE
[Breaking] Add support for watching multiple paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Browser hot reload for Python ASGI web apps.
 
 **What is this for?**
 
-`arel` can be used to implement development-only hot-reload for non-Python files that are not read from disk on each request. This may include GraphQL schemas, cached rendered Markdown content, etc.
+`arel` can be used to implement development-only hot-reload for non-Python files that are not read from disk on each request. This may include HTML templates, GraphQL schemas, cached rendered Markdown content, etc.
 
 **How does it work?**
 
@@ -33,12 +33,20 @@ _For a working example using Starlette, see the [Example](#example) section._
 
 Although the exact instructions to set up hot reload with `arel` depend on the specifics of your ASGI framework, there are three general steps to follow:
 
-1. Create an `HotReload` instance, passing a directory of files to watch:
+1. Create an `HotReload` instance, passing one or more directories of files to watch, and optionally a list of callbacks to call before a reload is triggered:
 
    ```python
    import arel
 
-   hotreload = arel.HotReload("./path/to/directory")
+   async def reload_data():
+       print("Reloading server data...")
+
+   hotreload = arel.HotReload(
+       paths=[
+           arel.Path("./server/data", on_reload=[reload_data]),
+           arel.Path("./server/static"),
+       ],
+   )
    ```
 
 2. Mount the hot reload endpoint, and register its startup and shutdown event handlers. If using Starlette, this can be done like this:
@@ -74,7 +82,7 @@ Although the exact instructions to set up hot reload with `arel` depend on the s
 
 ## Example
 
-The [`example` directory](https://github.com/florimondmanca/arel/tree/master/example) contains an example Markdown-powered website that uses `arel` to refresh the browser when Markdown content changes.
+The [`example` directory](https://github.com/florimondmanca/arel/tree/master/example) contains an example Markdown-powered website that uses `arel` to refresh the browser when Markdown content or HTML templates change.
 
 ## License
 

--- a/example/server/resources.py
+++ b/example/server/resources.py
@@ -5,7 +5,12 @@ import arel
 from . import settings
 from .content import load_pages
 
-hotreload = arel.HotReload(str(settings.PAGES_DIR), on_reload=[load_pages])
+hotreload = arel.HotReload(
+    paths=[
+        arel.Path(str(settings.PAGES_DIR), on_reload=[load_pages]),
+        arel.Path(str(settings.TEMPLATES_DIR)),
+    ],
+)
 
 templates = Jinja2Templates(directory=str(settings.TEMPLATES_DIR))
 templates.env.globals["DEBUG"] = settings.DEBUG

--- a/src/arel/__init__.py
+++ b/src/arel/__init__.py
@@ -1,4 +1,5 @@
 from .__version__ import __version__
 from ._app import HotReload
+from ._models import Path
 
-__all__ = ["__version__", "HotReload"]
+__all__ = ["__version__", "HotReload", "Path"]

--- a/src/arel/_models.py
+++ b/src/arel/_models.py
@@ -1,0 +1,8 @@
+from typing import NamedTuple, Sequence
+
+from ._types import ReloadFunc
+
+
+class Path(NamedTuple):
+    path: str
+    on_reload: Sequence[ReloadFunc] = ()

--- a/src/arel/_types.py
+++ b/src/arel/_types.py
@@ -1,0 +1,3 @@
+from typing import Awaitable, Callable
+
+ReloadFunc = Callable[[], Awaitable[None]]

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -29,6 +29,9 @@ async def test_example() -> None:
 
     async with websockets.connect("ws://localhost:8000/hot-reload") as ws:
         page1 = EXAMPLE_DIR / "pages" / "page1.md"
-        with make_change(page1):
-            message = await asyncio.wait_for(ws.recv(), timeout=1)
-        assert message == "reload"
+        index = EXAMPLE_DIR / "server" / "templates" / "index.jinja"
+        with make_change(page1), make_change(index):
+            assert await asyncio.wait_for(ws.recv(), timeout=1) == "reload"
+            assert await asyncio.wait_for(ws.recv(), timeout=1) == "reload"
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(ws.recv(), timeout=0.1)


### PR DESCRIPTION
Fixes #11 

Migration steps:

```python
hotreload = arel.HotReload("./path", on_reload=[...])
```

becomes:

```python
hotreload = arel.HotReload(
    paths=[
        arel.Path("./path", on_reload=[...]),
    ],
)
```