### PR TITLE
Bump dev dependencies

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,14 +7,14 @@ wheel
 # Example.
 jinja2==3.*
 markdown==3.3.*
-starlette==0.19.*
+starlette==0.20.*
 uvicorn==0.17.*
 
 # Tooling and tests.
 autoflake
-black==22.1.0
+black==22.3.0
 flake8
-httpx==0.22.*
+httpx==0.23.*
 isort==5.*
 mypy
 pytest


### PR DESCRIPTION
There's an issue with black on `master`: https://dev.azure.com/florimondmanca/public/_build/results?buildId=1520&view=logs&j=d4d03559-2ac6-55d9-0797-63a309766c09&t=05c9d8bf-2bc8-5c27-9319-5cfb0b2f9e17