### PR TITLE
Reload after reconnecting to the server

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ publish:
 	${bin}twine upload dist/*
 
 serve:
-	${bin}uvicorn example.server:app
+	${bin}uvicorn example.server:app --reload --reload-dir ./example
 
 test:
 	${bin}pytest

--- a/example/server/content.py
+++ b/example/server/content.py
@@ -12,8 +12,6 @@ async def load_pages() -> None:
         PAGES[path.name] = md.markdown(path.read_text())
 
 
-def get_page_content(page: Optional[str] = None) -> str:
-    if page is None:
-        page = "README"
+def get_page_content(page: str) -> Optional[str]:
     filename = f"{page}.md"
-    return PAGES[filename]
+    return PAGES.get(filename)

--- a/example/server/routes.py
+++ b/example/server/routes.py
@@ -1,5 +1,4 @@
-from typing import Optional
-
+from starlette.exceptions import HTTPException
 from starlette.requests import Request
 from starlette.responses import Response
 from starlette.routing import Route, WebSocketRoute
@@ -10,14 +9,21 @@ from .resources import hotreload, templates
 
 
 async def render(request: Request) -> Response:
-    page: Optional[str] = request.path_params.get("page")
-    context = {"request": request, "page_content": get_page_content(page)}
+    page: str = request.path_params.get("page", "README")
+
+    page_content = get_page_content(page)
+
+    if page_content is None:
+        raise HTTPException(404)
+
+    context = {"request": request, "page_content": page_content}
+
     return templates.TemplateResponse("index.jinja", context=context)
 
 
 routes: list = [
     Route("/", render),
-    Route("/{page}", render),
+    Route("/{page:path}", render),
 ]
 
 if settings.DEBUG:

--- a/src/arel/data/client.js
+++ b/src/arel/data/client.js
@@ -1,2 +1,53 @@
-const ws = new WebSocket("{url}");
-ws.onmessage = () => window.location.reload();
+
+function arel_connect(isReconnect = false) {
+    const reconnectInterval = parseFloat("$arel::reconnect_interval");
+  
+  const ws = new WebSocket("$arel::url");
+  
+  function log_info(msg) {
+    console.info(`[arel] ${msg}`);
+  }
+
+  ws.onopen = function () {
+    if (isReconnect) {
+      // The server may have disconnected while it was reloading itself,
+      // e.g. because the app Python source code has changed.
+      // The page content may have changed because of this, so we don't
+      // just want to reconnect, but also get that new page content.
+      // A simple way to do this is to reload the page.
+      window.location.reload();
+      return;
+    }
+
+    log_info("Connected.");
+  };
+
+  ws.onmessage = function (event) {
+    if (event.data === "reload") {
+      window.location.reload();
+    }
+  };
+
+  // Cleanly close the WebSocket before the page closes (1).
+  window.addEventListener("beforeunload", function () {
+    ws.close(1000);
+  });
+
+  ws.onclose = function (event) {
+    if (event.code === 1000) {
+      // Side-effect of (1). Ignore.
+      return;
+    }
+
+    log_info(
+      `WebSocket is closed. Will attempt reconnecting in ${reconnectInterval} seconds...`
+    );
+
+    setTimeout(function () {
+      const isReconnect = true;
+      arel_connect(isReconnect);
+    }, reconnectInterval * 1000);
+  };
+}
+
+arel_connect();


### PR DESCRIPTION
Right now `arel` doesn't handle server disconnects. So if e.g. Uvicorn is run with `--reload`, and a Python file is changed, the server disconnects, the WebSocket connection breaks, and nothing happens.

This PR upgrades the JS script so that it attempts reconnecting to the server, and reload the page when the server comes back up to get fresh HTML content.

This is based on https://github.com/Kludex/uvicorn-extensions/issues/15#issuecomment-1312724004

TODO

* [x] Update tests. Edit: we don't actually test the JS client code. So, done. Maybe we could consider proper E2E tests with Playwright? Hmm.
