### PR TITLE
Version 0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.3.0 - 2023-12-29
+
+### Changed
+
+- Use `watchfiles` instead of `watchgod`. This unlocks Python 3.12 support. (Pull #34)
+
+### Added
+
+- Add support for Python 3.12. (Pull #35)
+
 ## 0.2.0 - 2020-07-08
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Browser hot reload for Python ASGI web apps.
 ## Installation
 
 ```bash
-pip install 'arel==0.2.*'
+pip install 'arel==0.3.*'
 ```
 
 ## Quickstart

--- a/src/arel/__init__.py
+++ b/src/arel/__init__.py
@@ -1,6 +1,6 @@
 from ._app import HotReload
 from ._models import Path
 
-__version__ = "0.2.0"
+__version__ = "0.3.0"
 
 __all__ = ["__version__", "HotReload", "Path"]


### PR DESCRIPTION
## 0.3.0 - 2023-12-29

### Changed

- Use `watchfiles` instead of `watchgod`. This unlocks Python 3.12 support. (Pull #34)

### Added

- Add support for Python 3.12. (Pull #35)
