### PR TITLE
[WIP] Asset reload

### DIFF
--- a/src/arel/_app.py
+++ b/src/arel/_app.py
@@ -39,10 +39,20 @@ class HotReload:
         self, changeset: ChangeSet, *, on_reload: List[ReloadFunc]
     ) -> None:
         description = ", ".join(
-            f"file {event} at {', '.join(f'{event!r}' for event in changeset[event])}"
+            f"file {event} at {', '.join(f'{file!r}' for file in changeset[event])}"
             for event in changeset
         )
         logger.warning("Detected %s. Triggering reload...", description)
+
+        all_files = []
+        for event in changeset:
+            all_files.extend(changeset[event])
+
+        only_css_changes = all(all_files.endswith(".css") for all_files in all_files)
+        if only_css_changes:
+            for file in all_files:
+                await self.notify.notify_css(file)
+            return
 
         # Run server-side hooks first.
         for callback in on_reload:

--- a/src/arel/_app.py
+++ b/src/arel/_app.py
@@ -81,8 +81,8 @@ class HotReload:
             pass  # pragma: no cover
 
     async def _watch_reloads(self, ws: WebSocket) -> None:
-        async for _ in self.notify.watch():
-            await ws.send_text("reload")
+        async for msg in self.notify.watch():
+            await ws.send_text(msg)
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         assert scope["type"] == "websocket"

--- a/src/arel/_notify.py
+++ b/src/arel/_notify.py
@@ -10,10 +10,10 @@ class Notify:
     async def notify(self) -> None:
         await self._broadcast.publish("reload")
 
-    async def watch(self) -> AsyncIterator[None]:
+    async def watch(self) -> AsyncIterator[str]:
         async with self._broadcast.subscribe() as subscription:
-            async for _ in subscription:
-                yield
+            async for msg in subscription:
+                yield msg
 
 
 class _MemoryBroadcast:

--- a/src/arel/_notify.py
+++ b/src/arel/_notify.py
@@ -1,6 +1,7 @@
 import asyncio
 from contextlib import asynccontextmanager
 from typing import AsyncIterator, Set
+import pathlib
 
 
 class Notify:
@@ -9,6 +10,10 @@ class Notify:
 
     async def notify(self) -> None:
         await self._broadcast.publish("reload")
+
+    async def notify_css(self, filepath: pathlib.Path) -> None:
+        filename = pathlib.Path(filepath).name
+        await self._broadcast.publish(f"update_css:{filename}")
 
     async def watch(self) -> AsyncIterator[str]:
         async with self._broadcast.subscribe() as subscription:

--- a/src/arel/data/client.js
+++ b/src/arel/data/client.js
@@ -1,53 +1,82 @@
-
 function arel_connect(isReconnect = false) {
     const reconnectInterval = parseFloat("$arel::reconnect_interval");
-  
-  const ws = new WebSocket("$arel::url");
-  
-  function log_info(msg) {
-    console.info(`[arel] ${msg}`);
-  }
 
-  ws.onopen = function () {
-    if (isReconnect) {
-      // The server may have disconnected while it was reloading itself,
-      // e.g. because the app Python source code has changed.
-      // The page content may have changed because of this, so we don't
-      // just want to reconnect, but also get that new page content.
-      // A simple way to do this is to reload the page.
-      window.location.reload();
-      return;
+    const ws = new WebSocket("$arel::url");
+
+    function log_info(msg) {
+        console.info(`[arel] ${msg}`);
     }
 
-    log_info("Connected.");
-  };
+    function update_css(file) {
+        // Appends the timestamp query string to file to force
+        // the browser to reload the CSS file.
 
-  ws.onmessage = function (event) {
-    if (event.data === "reload") {
-      window.location.reload();
-    }
-  };
+        const links = document.querySelectorAll(`link[href*="/${file}"]`);
+        const timestamp = new Date().getTime();
 
-  // Cleanly close the WebSocket before the page closes (1).
-  window.addEventListener("beforeunload", function () {
-    ws.close(1000);
-  });
-
-  ws.onclose = function (event) {
-    if (event.code === 1000) {
-      // Side-effect of (1). Ignore.
-      return;
+        links.forEach(link => {
+            const href = link.href.split('?')[0];
+            const newHref = `${href}?${timestamp}`;
+            log_info(`Updating CSS file ${href} to ${newHref}`);
+            link.href = newHref;
+        });
     }
 
-    log_info(
-      `WebSocket is closed. Will attempt reconnecting in ${reconnectInterval} seconds...`
-    );
+    ws.onopen = function () {
+        if (isReconnect) {
+            // The server may have disconnected while it was reloading itself,
+            // e.g. because the app Python source code has changed.
+            // The page content may have changed because of this, so we don't
+            // just want to reconnect, but also get that new page content.
+            // A simple way to do this is to reload the page.
+            window.location.reload();
+            return;
+        }
 
-    setTimeout(function () {
-      const isReconnect = true;
-      arel_connect(isReconnect);
-    }, reconnectInterval * 1000);
-  };
+        log_info("Connected.");
+    };
+
+    ws.onmessage = function (event) {
+        log_info(`Received message: ${event.data}`);
+        // Commands:
+        //   reload
+        //   update_css:filename
+        cmd = event.data.split(":")[0];
+
+        switch (cmd) {
+            case "reload":
+                log_info("Reloading...");
+                window.location.reload();
+                break;
+            case "update_css":
+                file = event.data.split(":")[1];
+                update_css(file);
+                break;
+            default:
+                log_info("Received unknown command:", event.data);
+        }
+    };
+
+    // Cleanly close the WebSocket before the page closes (1).
+    window.addEventListener("beforeunload", function () {
+        ws.close(1000);
+    });
+
+    ws.onclose = function (event) {
+        if (event.code === 1000) {
+            // Side-effect of (1). Ignore.
+            return;
+        }
+
+        log_info(
+            `WebSocket is closed. Will attempt reconnecting in ${reconnectInterval} seconds...`
+        );
+
+        setTimeout(function () {
+            const isReconnect = true;
+            arel_connect(isReconnect);
+        }, reconnectInterval * 1000);
+    };
 }
 
 arel_connect();


### PR DESCRIPTION
This is currently a hacky proof of concept for hot-reloading only a specific asset.

Basically I've updated the Arel server to tell the client which file has changed.
Then I've also made the client be able to just patch in the specific change.

Right now I have hardcoded it to only patch reload css files, and only if no other file types have been changed.

This not only unlocks a _much_ faster reload, but for more complex apps, it allow you to get into a certain state and then fiddle with the css without losing state.