### PR TITLE
Version 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,20 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.4.0 - 2025-09-22
+
+### Removed
+
+- Drop support for Python 3.7 and 3.8 (EOL versions). (Pull #39)
+
+### Added
+
+- Add support for Python 3.13. (Pull #39)
+
+### Fixed
+
+- Update watchfiles dependency to support modern versions (>=0.18,<2.0). (Pull #39)
+
 ## 0.3.0 - 2023-12-29
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Browser hot reload for Python ASGI web apps.
 ## Installation
 
 ```bash
-pip install 'arel==0.3.*'
+pip install 'arel==0.4.*'
 ```
 
 ## Quickstart

--- a/ci/azure-pipelines.yml
+++ b/ci/azure-pipelines.yml
@@ -4,7 +4,7 @@ resources:
       type: github
       endpoint: github
       name: florimondmanca/azure-pipelines-templates
-      ref: refs/tags/6.2
+      ref: refs/tags/6.4.2
 
 trigger:
   - master

--- a/src/arel/__init__.py
+++ b/src/arel/__init__.py
@@ -1,6 +1,6 @@
 from ._app import HotReload
 from ._models import Path
 
-__version__ = "0.3.0"
+__version__ = "0.4.0"
 
 __all__ = ["__version__", "HotReload", "Path"]


### PR DESCRIPTION
## 0.4.0 - 2025-09-22

### Removed

- Drop support for Python 3.7 and 3.8 (EOL versions). (Pull #39)

### Added

- Add support for Python 3.13. (Pull #39)

### Fixed

- Update watchfiles dependency to support modern versions (>=0.18,<2.0). (Pull #39)