### PR TITLE
Add optional nonce parameter to HotReload.script()

### DIFF
--- a/src/arel/_app.py
+++ b/src/arel/_app.py
@@ -50,7 +50,7 @@ class HotReload:
 
         await self.notify.notify()
 
-    def script(self, url: str) -> str:
+    def script(self, url: str, nonce: str = "") -> str:
         if not hasattr(self, "_script_template"):
             self._script_template = _Template(SCRIPT_TEMPLATE_PATH.read_text())
 
@@ -58,7 +58,8 @@ class HotReload:
             {"url": url, "reconnect_interval": self._reconnect_interval}
         )
 
-        return f"<script>{content}</script>"
+        nonce_attr = f' nonce="{nonce}"' if nonce else ""
+        return f"<script{nonce_attr}>{content}</script>"
 
     async def startup(self) -> None:
         try:

--- a/tests/test_example.py
+++ b/tests/test_example.py
@@ -3,6 +3,7 @@ from contextlib import contextmanager
 from pathlib import Path
 from typing import Iterator
 
+import arel
 import httpx
 import pytest
 
@@ -20,6 +21,17 @@ def make_change(path: Path) -> Iterator[None]:
         yield
     finally:
         path.write_text(content)
+
+
+def test_script_nonce() -> None:
+    hotreload = arel.HotReload(paths=[])
+    script_without_nonce = hotreload.script("/hot-reload")
+    assert script_without_nonce.startswith("<script>")
+    assert "nonce" not in script_without_nonce
+
+    script_with_nonce = hotreload.script("/hot-reload", nonce="abc123")
+    assert script_with_nonce.startswith('<script nonce="abc123">')
+    assert script_with_nonce.endswith("</script>")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
## Summary

Applications using Content Security Policy with nonce-based `script-src` directives currently can't use arel without either weakening their CSP or disabling hot-reload entirely. Every inline `<script>` tag needs to carry the per-request nonce, and `HotReload.script()` doesn't support that.

This adds an optional `nonce` parameter:

```python
hotreload.script(url_for("hot-reload"), nonce=request.state.csp_nonce)
```

When provided, the generated tag becomes `<script nonce="...">`. When omitted, behavior is identical to today — fully backwards compatible, no changes needed for existing users.

This feature was suggested by @dlopcol

## Test plan

- Added `test_script_nonce` covering both default (no nonce) and nonce cases
- All existing tests pass, 100% coverage maintained