### PR TITLE
Support Starlette 1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,16 +47,25 @@ Although the exact instructions to set up hot reload with `arel` depend on the s
    )
    ```
 
-2. Mount the hot reload endpoint, and register its startup and shutdown event handlers. If using Starlette, this can be done like this:
+2. Mount the hot reload endpoint, and wire its startup and shutdown into the application's lifespan. If using Starlette, this can be done like this:
 
    ```python
+   from contextlib import asynccontextmanager
+
    from starlette.applications import Starlette
    from starlette.routing import WebSocketRoute
 
+
+   @asynccontextmanager
+   async def lifespan(app):
+       await hotreload.startup()
+       yield
+       await hotreload.shutdown()
+
+
    app = Starlette(
        routes=[WebSocketRoute("/hot-reload", hotreload, name="hot-reload")],
-       on_startup=[hotreload.startup],
-       on_shutdown=[hotreload.shutdown],
+       lifespan=lifespan,
    )
    ```
 

--- a/example/server/app.py
+++ b/example/server/app.py
@@ -1,12 +1,11 @@
 from starlette.applications import Starlette
 
 from . import settings
-from .events import on_shutdown, on_startup
+from .events import lifespan
 from .routes import routes
 
 app = Starlette(
     debug=settings.DEBUG,
     routes=routes,
-    on_startup=on_startup,
-    on_shutdown=on_shutdown,
+    lifespan=lifespan,
 )

--- a/example/server/events.py
+++ b/example/server/events.py
@@ -1,10 +1,18 @@
+from contextlib import asynccontextmanager
+from typing import AsyncIterator
+
+from starlette.applications import Starlette
+
 from . import settings
 from .content import load_pages
 from .resources import hotreload
 
-on_startup = [load_pages]
-on_shutdown = []
 
-if settings.DEBUG:
-    on_startup += [hotreload.startup]
-    on_shutdown += [hotreload.shutdown]
+@asynccontextmanager
+async def lifespan(app: Starlette) -> AsyncIterator[None]:
+    await load_pages()
+    if settings.DEBUG:
+        await hotreload.startup()
+    yield
+    if settings.DEBUG:
+        await hotreload.shutdown()

--- a/example/server/routes.py
+++ b/example/server/routes.py
@@ -16,9 +16,9 @@ async def render(request: Request) -> Response:
     if page_content is None:
         raise HTTPException(404)
 
-    context = {"request": request, "page_content": page_content}
+    context = {"page_content": page_content}
 
-    return templates.TemplateResponse("index.jinja", context=context)
+    return templates.TemplateResponse(request, "index.jinja", context=context)
 
 
 routes: list = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,8 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-  "starlette==0.*",
+  "anyio>=3.4,<5",
+  "starlette>=0.21,<2.0",
   "watchfiles>=0.18,<2.0",
 ]
 dynamic = ["version", "readme"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,8 @@ wheel
 # Example.
 jinja2==3.*
 markdown==3.*
-starlette>=1.0,<2.0
+starlette>=1.0,<2.0 ; python_version >= "3.10"
+starlette<1.0 ; python_version < "3.10"
 uvicorn==0.19.*
 
 # Tooling and tests.

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ wheel
 # Example.
 jinja2==3.*
 markdown==3.*
-starlette==0.21.*
+starlette>=1.0,<2.0
 uvicorn==0.19.*
 
 # Tooling and tests.

--- a/src/arel/_app.py
+++ b/src/arel/_app.py
@@ -2,9 +2,9 @@ import functools
 import logging
 import pathlib
 import string
-from typing import List, Sequence
+from typing import Awaitable, Callable, List, Sequence
 
-from starlette.concurrency import run_until_first_complete
+import anyio
 from starlette.types import Receive, Scope, Send
 from starlette.websockets import WebSocket
 
@@ -88,7 +88,11 @@ class HotReload:
         assert scope["type"] == "websocket"
         ws = WebSocket(scope, receive, send)
         await ws.accept()
-        await run_until_first_complete(
-            (self._watch_reloads, {"ws": ws}),
-            (self._wait_client_disconnect, {"ws": ws}),
-        )
+        async with anyio.create_task_group() as task_group:
+
+            async def run(func: Callable[[WebSocket], Awaitable[None]]) -> None:
+                await func(ws)
+                task_group.cancel_scope.cancel()
+
+            task_group.start_soon(run, self._watch_reloads)
+            task_group.start_soon(run, self._wait_client_disconnect)


### PR DESCRIPTION
Adds support for Starlette 1.0 alongside the existing 0.x line.

Starlette 1.0 removed `on_startup` / `on_shutdown` from `Starlette.__init__` and reordered `Jinja2Templates.TemplateResponse` to take `Request` first. Library code in `src/arel/` keeps working under 1.0; the README's documented integration pattern and the example app do not.

- Widen runtime constraint to `starlette>=0.21,<2.0`.
- Migrate the README quickstart and `example/` from `on_startup`/`on_shutdown` to `lifespan` (supported since 0.13, so works on both ranges).
- Update `example/server/routes.py` to the new `TemplateResponse` signature.
- Replace deprecated `run_until_first_complete` in `HotReload.__call__` with `anyio.create_task_group` (silences the `DeprecationWarning` users see on 1.0). Adds `anyio>=3.4,<5` as an explicit dep (already transitive via Starlette).

<details>
<summary>CI matrix coverage</summary>

`requirements.txt` pins starlette by Python version: py39 tests against 0.x (resolves to 0.49.x), py310+ tests against 1.0. Required because starlette 1.0 dropped Python 3.9 support.
</details>