### PR TITLE
Document try/finally for asynccontextmanager lifespan yield

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,8 +59,10 @@ Although the exact instructions to set up hot reload with `arel` depend on the s
    @asynccontextmanager
    async def lifespan(app):
        await hotreload.startup()
-       yield
-       await hotreload.shutdown()
+       try:
+           yield
+       finally:
+           await hotreload.shutdown()
 
 
    app = Starlette(

--- a/example/server/events.py
+++ b/example/server/events.py
@@ -13,6 +13,8 @@ async def lifespan(app: Starlette) -> AsyncIterator[None]:
     await load_pages()
     if settings.DEBUG:
         await hotreload.startup()
-    yield
-    if settings.DEBUG:
-        await hotreload.shutdown()
+    try:
+        yield
+    finally:
+        if settings.DEBUG:
+            await hotreload.shutdown()


### PR DESCRIPTION
Wrap lifespan yield in try/finally so hotreload.shutdown() runs even if the app errors during its lifetime, preventing leaked FileWatcher threads