### PR TITLE
Version 0.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## 0.5.0 - 2026-08-02
+
+### Added
+
+- Add support for Starlette 1.x. (Pull #42)
+
+### Changed
+
+- Widen the `starlette` dependency to `>=0.21,<2.0`, and add `anyio>=3.4,<5` as a direct dependency. (Pull #42)
+- Use `anyio.create_task_group()` instead of Starlette's deprecated `run_until_first_complete`. (Pull #42)
+- Register `hotreload.startup` and `hotreload.shutdown` from a `lifespan` context manager. Starlette 1.0 removed the `on_startup` and `on_shutdown` arguments. (Pull #42, #43)
+
 ## 0.4.0 - 2025-09-22
 
 ### Removed

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Browser hot reload for Python ASGI web apps.
 ## Installation
 
 ```bash
-pip install 'arel==0.4.*'
+pip install 'arel==0.5.*'
 ```
 
 ## Quickstart

--- a/src/arel/__init__.py
+++ b/src/arel/__init__.py
@@ -1,6 +1,6 @@
 from ._app import HotReload
 from ._models import Path
 
-__version__ = "0.4.0"
+__version__ = "0.5.0"
 
 __all__ = ["__version__", "HotReload", "Path"]


### PR DESCRIPTION
## 0.5.0 - 2026-08-02

### Added

- Add support for Starlette 1.x. (Pull #42)

### Changed

- Widen the `starlette` dependency to `>=0.21,<2.0`, and add `anyio>=3.4,<5` as a direct dependency. (Pull #42)
- Use `anyio.create_task_group()` instead of Starlette's deprecated `run_until_first_complete`. (Pull #42)
- Register `hotreload.startup` and `hotreload.shutdown` from a `lifespan` context manager. Starlette 1.0 removed the `on_startup` and `on_shutdown` arguments. (Pull #42, #43)
